### PR TITLE
Implement user analytics redux

### DIFF
--- a/src/action_types/users.js
+++ b/src/action_types/users.js
@@ -153,6 +153,10 @@ export default keyMirror({
     ENABLE_USER_ACCESS_TOKEN_SUCCESS: null,
     ENABLE_USER_ACCESS_TOKEN_FAILURE: null,
 
+    GET_USER_ANALYTICS_REQUEST: null,
+    GET_USER_ANALYTICS_SUCCESS: null,
+    GET_USER_ANALYTICS_FAILURE: null,
+
     RECEIVED_ME: null,
     RECEIVED_PROFILE: null,
     RECEIVED_PROFILES: null,
@@ -184,4 +188,5 @@ export default keyMirror({
     DISABLED_USER_ACCESS_TOKEN: null,
     ENABLED_USER_ACCESS_TOKEN: null,
     RECEIVED_USER_STATS: null,
+    RECEIVED_USER_ANALYTICS: null,
 });

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -312,6 +312,24 @@ export default class Client4 {
         );
     };
 
+    /**
+     * Get the 'name' UserAnalytics data for the specified user in the specified team
+     * from the mattermost-server. UserAnalytics are based on interactions the
+     * user had in a particular team.
+     *
+     * @param {string} userId - The target user for the requested analytics
+     * @param {string} teamId - The target team for the requested analytics
+     * @param {string} name - The name of the type of analytic data to return
+     *
+     * @returns {Promise<object>} containing the particular analytics requested
+     */
+    getUserAnalytics = async (userId, teamId, name) => {
+        return this.doFetch(
+            `${this.getUserRoute(userId)}/teams/${teamId}/useranalytics${buildQueryString({name})}`,
+            {method: 'get'}
+        );
+    };
+
     patchMe = async (userPatch) => {
         return this.doFetch(
             `${this.getUserRoute('me')}/patch`,

--- a/src/constants/preferences.js
+++ b/src/constants/preferences.js
@@ -69,7 +69,7 @@ export default {
             mentionHighlightBg: '#fdff8e',
             mentionHighlightLink: '#0f758e',
             mentionBg: '#fbfbfb',
-            codeTheme: 'github'
+            codeTheme: 'github',
         },
         mattermost: {
             type: 'Mattermost',

--- a/src/constants/user_analytics.js
+++ b/src/constants/user_analytics.js
@@ -1,0 +1,14 @@
+// Copyright (c) 2018-present Riff Learning, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+/* eslint-disable header/header */
+
+/**
+ * These strings are identifiers for user analytics data sets
+ * The values use pascal casing instead of underscore delimited because the structs on
+ * the backend (golang) like pascal casing for the names of fields
+ */
+export const Datasets = {
+    USER_LEARNING_GROUPS: 'UserLearningGroups',
+    LEARNING_GROUP_TYPES: 'LearningGroupTypes',
+    USER_INTERACTIONS: 'UserInteractions',
+};

--- a/src/reducers/entities/users.js
+++ b/src/reducers/entities/users.js
@@ -72,6 +72,38 @@ function removeProfileFromSet(state, action) {
     };
 }
 
+/**
+ * This reducer manipulates the entities.users.analytics object in the store
+ * It handles 2 actions:
+ *     1. RECEIVED_USER_ANALYTICS
+ *        - user analytics data was just received, add it to the analytics object
+ *     2. LOGOUT_SUCCESS
+ *        - any analytics retrieved by the logged in user must be removed when that user logs out
+ * The GenericAction type is strictly defined so, data is returned as action.data.data and name as action.data.name
+ * name (the name of the data set that was initially requested) is not used in this entity, since all user analytics
+ * data sets are stored under the main analytics object
+ * But the name of the data set that was initially requested may be of use here later
+ *
+ * @param {object} state - containing the current entities.users.analytics state
+ * @param {object} action - containing data for each action
+ *
+ * @returns {object} containing the new entities.users.analytics state
+ */
+function analytics(state = {}, action) {
+    switch (action.type) {
+    case UserTypes.RECEIVED_USER_ANALYTICS: {
+        return {
+            ...state,
+            ...action.data.data,
+        };
+    }
+    case UserTypes.LOGOUT_SUCCESS:
+        return {};
+    default:
+        return state;
+    }
+}
+
 function currentUserId(state = '', action) {
     switch (action.type) {
     case UserTypes.RECEIVED_ME: {
@@ -365,6 +397,9 @@ function stats(state = {}, action) {
 }
 
 export default combineReducers({
+
+    // object where each type of data is defined in Datasets in constants/user_analytics.js
+    analytics,
 
     // the current selected user
     currentUserId,

--- a/src/reducers/requests/users.js
+++ b/src/reducers/requests/users.js
@@ -148,6 +148,57 @@ function getUser(state: RequestStatusType = initialRequestState(), action: Gener
     );
 }
 
+/* ******************************************************************************
+ * getUserAnalytics                                                        */ /**
+ *
+ * Reducer for getUserAnalytics. Because the getUserAnalytics is parameterized
+ * by a name which determines what is actually being requested and returned,
+ * the status for the particular named analytics needs to be tracked.
+ *
+ * The request state is in a property with the analytic's name as the key, and
+ * that is why the initial state is an empty object instead of initialRequestState()
+ *
+ * @example
+ * if you request the name 'UserInteractions', and it succeeds, the state will
+ * look as follows:
+ * getUserAnalytics: {
+ *    UserInteractions: {
+ *        status: success,
+ *        error: null,
+ *    }
+ * }
+ *
+ * @param {object} state - containing RequestStatusType objects for every user analytics request
+ * @param {GenericAction} action - containing data for each action
+ *
+ * @returns {object} containing the new requests.users.getUserAnalytics state
+ */
+function getUserAnalytics(state: Object = {}, action: GenericAction): Object {
+    const HANDLED_ACTION_TYPES = [
+        UserTypes.GET_USER_ANALYTICS_REQUEST,
+        UserTypes.GET_USER_ANALYTICS_SUCCESS,
+        UserTypes.GET_USER_ANALYTICS_FAILURE,
+    ];
+
+    // We only want to create request state if the action is a GET_USER_ANALYTICS request action
+    // so we check for an action type we want to handle up front.
+    if (!HANDLED_ACTION_TYPES.some((type) => type === action.type)) {
+        return state;
+    }
+
+    // Use the standard handleRequest helper to update the named analytics request state
+    // property.
+    const curUserAnalyticsNameState = state[action.data.name] || initialRequestState();
+    return {
+        ...state,
+        [action.data.name]: handleRequest(
+            ...HANDLED_ACTION_TYPES,
+            curUserAnalyticsNameState,
+            action
+        ),
+    };
+}
+
 function getUserByUsername(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
     return handleRequest(
         UserTypes.USER_BY_USERNAME_REQUEST,
@@ -422,6 +473,7 @@ export default combineReducers({
     getProfilesInChannel,
     getProfilesNotInChannel,
     getUser,
+    getUserAnalytics,
     getUserByUsername,
     getStatusesByIds,
     getStatus,

--- a/src/store/initial_state.js
+++ b/src/store/initial_state.js
@@ -28,6 +28,10 @@ const state: GlobalState = {
             profilesNotInChannel: {},
             statuses: {},
             stats: {},
+            analytics: {
+
+                // The key for each type of data is defined in Datasets in constants/user_analytics.js
+            },
         },
         teams: {
             currentTeamId: '',
@@ -333,6 +337,10 @@ const state: GlobalState = {
             getUser: {
                 status: 'not_started',
                 error: null,
+            },
+            getUserAnalytics: {
+
+                // The key for each type of data is defined in Datasets in constants/user_analytics.js
             },
             getUserByUsername: {
                 status: 'not_started',

--- a/src/types/requests.js
+++ b/src/types/requests.js
@@ -84,7 +84,11 @@ export type UsersRequestsStatuses = {|
     autocompleteUsers: RequestStatusType,
     searchProfiles: RequestStatusType,
     updateMe: RequestStatusType,
-    getTotalUsersStats: RequestStatusType
+    getTotalUsersStats: RequestStatusType,
+
+    // An object containing multiple RequestStatusTypes,
+    // under the key of the dataset that was initially requested
+    getUserAnalytics: Object,
 |};
 
 export type PreferencesRequestsStatuses = {|

--- a/src/types/users.js
+++ b/src/types/users.js
@@ -31,4 +31,5 @@ export type UsersState = {|
     profilesNotInChannel: {[string]: Array<string>},
     statuses: {[string]: string},
     stats: Object,
+    analytics: Object,
 |};


### PR DESCRIPTION
#### Summary
This pull request accommodates requests for user analytics from the front-end, makes a call to the server, and finally stores the user analytics data in the store, to be accessed by the front-end.

**1.** Using the getUserAnalytics 'GET' request, the `/users/{userId}/teams/{teamId}/useranalytics?name={name}` route is called in mattermost-server
    a. userId is the id of the user that is currently logged in
    b. teamId is the id of the mattermost team that is currently selected
    c. the query parameter 'name' is the dataset that you want to retrieve

**2.** To store and keep track of every getUserAnalytics request, a getUserAnalytics object was added to the requests.users object. Request status information for each dataset request is stored in getUserAnalytics, under the dataset name as the key. This follows closely how the existing api requests operate, except it handles and tracks, dynamically, any getUserAnalytics request (requests that request different datasets). 

**3.** If the request is successful, the user analytics data is stored in the redux object `entities.users.analytics`, having keys equal to names of datasets. In addition to the datasets, the key TargetUser holds the userId that these analytics were fetched for. A to-do in the future is to maybe make analytics an array, which can hold analytics for multiple users, using this TargetUser field in each object for reference. 

Note** Datasets are defined in an object in src/constants/user_analytics.js as Datasets 
The values (datasets) are:
    - UserLearningGroups (is always returned)
    - LearningGroupTypes (is always returned)
    - UserInteractions (must be specified to return ie. passed as name in the request)
    - _**potentially another analytics data set could be added here, to be used for additional graphs in the dashboard or other purposes**_

#### Ticket Link
https://app.zenhub.com/workspaces/riff-projects-5cb6029b4103d93ceadf001b/issues/rifflearning/zenhub/100

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed