### PR TITLE
Fix broken tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ mattermost-redux-*.tgz
 # flow
 /flow-typed
 /.flowinstall
+
+# test coverage
+coverage/
+.nyc_output/

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "harmony-reflect": "1.6.0",
     "isomorphic-fetch": "2.2.1",
     "mime-db": "1.33.0",
+    "nyc": "^14.1.1",
     "redux": "4.0.0",
     "redux-action-buffer": "1.2.0",
     "redux-batched-actions": "0.3.0",
@@ -74,6 +75,7 @@
     "flow": "flow",
     "flow-typed": "flow-typed",
     "test": "NODE_ENV=test mocha --opts test/mocha.opts",
+    "test:coverage": "NODE_ENV=test nyc --reporter=text mocha --opts test/mocha.opts",
     "prepare": "npm run build"
   }
 }

--- a/test/actions/channels.test.js
+++ b/test/actions/channels.test.js
@@ -1427,7 +1427,7 @@ describe('Actions.Channels', () => {
         assert.ok(channel);
         assert.ok(notChannel);
         assert.ok(channel.has(user.id));
-        assert.ifError(notChannel.has(user.id));
+        assert.equal(notChannel.has(user.id), false, 'user should not present in profilesNotInChannel');
 
         stats = state.entities.channels.stats;
         assert.ok(stats, 'stats');
@@ -1495,7 +1495,7 @@ describe('Actions.Channels', () => {
         assert.ok(channel);
         assert.ok(notChannel);
         assert.ok(notChannel.has(user.id));
-        assert.ifError(channel.has(user.id));
+        assert.equal(channel.has(user.id), false, 'user should not present in profilesInChannel');
 
         stats = state.entities.channels.stats;
         assert.ok(stats, 'stats');

--- a/test/selectors/channels.test.js
+++ b/test/selectors/channels.test.js
@@ -358,7 +358,7 @@ describe('Selectors.Channels', () => {
         assert.ok(fromOriginalState === fromModifiedState);
 
         // it should't have a channel that belongs to a team
-        assert.ifError(fromModifiedState.includes(channel1.id));
+        assert.equal(fromModifiedState.includes(channel1.id), false, 'should not have a channel that belongs to a team');
     });
 
     it('get channel ids in current team strict equal', () => {
@@ -390,7 +390,7 @@ describe('Selectors.Channels', () => {
         assert.ok(fromOriginalState === fromModifiedState);
 
         // it should't have a direct channel
-        assert.ifError(fromModifiedState.includes(channel7.id));
+        assert.equal(fromModifiedState.includes(channel7.id), false, 'should not have direct channel on a team');
     });
 
     it('get channel ids for current team strict equal', () => {


### PR DESCRIPTION
#### Summary
Fix all four broken tests by seeing what the master branch in mm-redux repo had done...fairly trivial changes

Added nyc package to get test coverage with mocha, and added 'npm run test:coverage' as a script in package.json

Added nyc's output files/folders to gitignore

#### Ticket Link
rifflearning/zenhub/#181

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed